### PR TITLE
Fix broken link in PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ https://github.com/blog/1506-closing-issues-via-pull-requests for more
 information.
 
 ### checklist
-- [ ] Make sure you read and understood the [CONTRIBUTING.md](/.github/CONTRIBUTING.md).
+- [ ] Make sure you read and understood the [CONTRIBUTING.md](https://github.com/xh3b4sd/anna/.github/CONTRIBUTING.md).
 - [ ] Make sure you applied sufficient labels, milestone and assignee.
 - [ ] Make sure all TODOs are addressed.
 - [ ] Make sure there is sufficient documentation.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ https://github.com/blog/1506-closing-issues-via-pull-requests for more
 information.
 
 ### checklist
-- [ ] Make sure you read and understood the [CONTRIBUTING.md](/.github.com/CONTRIBUTING.md).
+- [ ] Make sure you read and understood the [CONTRIBUTING.md](/.github/CONTRIBUTING.md).
 - [ ] Make sure you applied sufficient labels, milestone and assignee.
 - [ ] Make sure all TODOs are addressed.
 - [ ] Make sure there is sufficient documentation.


### PR DESCRIPTION
### abstract
Fix broken link in PR template. For a concrete example, try clicking on the `CONTRIBUTING.md` link in the checklist below. It should result in a 404 prior to the merge of this PR.

### fixes
Please provide here the issues this pull requests fixes. You may want to make
use of Github's feature to automatically close issues via pull requests. See
https://github.com/blog/1506-closing-issues-via-pull-requests for more
information.

### checklist
- [ ] Make sure you read and understood the [CONTRIBUTING.md](/.github.com/CONTRIBUTING.md).
- [ ] Make sure you applied sufficient labels, milestone and assignee.
- [ ] Make sure all TODOs are addressed.
- [ ] Make sure there is sufficient documentation.
- [ ] Make sure there are sufficient tests.
- [ ] Make sure all commits are squashed before merging.
- [ ] Make sure to delete the feature branch after merging.

