### PR TITLE
Network payload

### DIFF
--- a/clg/divide/generated.go
+++ b/clg/divide/generated.go
@@ -25,6 +25,9 @@ type Config struct {
 	// Dependencies.
 	Log     spec.Log
 	Storage spec.Storage
+
+	// Settings.
+	InputChannel chan spec.NetworkPayload
 }
 
 // DefaultConfig provides a default configuration to create a new CLG object by
@@ -39,6 +42,9 @@ func DefaultConfig() Config {
 		// Dependencies.
 		Log:     log.NewLog(log.DefaultConfig()),
 		Storage: newStorage,
+
+		// Settings.
+		InputChannel: make(chan spec.NetworkPayload, 1000),
 	}
 
 	return newConfig
@@ -52,11 +58,17 @@ func New(config Config) (spec.CLG, error) {
 		Type:   ObjectType,
 	}
 
+	// Dependencies.
 	if newCLG.Log == nil {
 		return nil, maskAnyf(invalidConfigError, "logger must not be empty")
 	}
 	if newCLG.Storage == nil {
 		return nil, maskAnyf(invalidConfigError, "storage must not be empty")
+	}
+
+	// Settings.
+	if newCLG.InputChannel == nil {
+		return nil, maskAnyf(invalidConfigError, "input channel must not be empty")
 	}
 
 	newCLG.Log.Register(newCLG.GetType())
@@ -81,29 +93,39 @@ type clg struct {
 	Type spec.ObjectType
 }
 
-func (c *clg) Calculate(inputs []reflect.Value) ([]reflect.Value, error) {
-	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(inputs))
+func (c *clg) Calculate(payload spec.NetworkPayload) (spec.NetworkPayload, error) {
+	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(payload.Args))
 	if err != nil {
-		return nil, maskAny(err)
+		return spec.NetworkPayload{}, maskAny(err)
 	}
 
-	return outputs, nil
+	calculatedPayload := spec.NetworkPayload{
+		Args:        outputs,
+		Destination: "", // This has to be decided by Network.Forward.
+		Sources:     []spec.ObjectID{payload.Destination},
+	}
+
+	return calculatedPayload, nil
 }
 
 func (c *clg) GetName() string {
 	return "divide"
 }
 
-func (c *clg) Inputs() []reflect.Type {
+func (c *clg) GetInputChannel() chan spec.NetworkPayload {
+	return c.InputChannel
+}
+
+func (c *clg) GetInputTypes() []reflect.Type {
 	t := reflect.TypeOf(c.calculate)
 
-	var clgInputs []reflect.Type
+	var inputType []reflect.Type
 
 	for i := 0; i < t.NumIn(); i++ {
-		clgInputs = append(clgInputs, t.In(i))
+		inputType = append(inputType, t.In(i))
 	}
 
-	return clgInputs
+	return inputType
 }
 
 func (c *clg) SetLog(log spec.Log) {

--- a/clg/greater/generated.go
+++ b/clg/greater/generated.go
@@ -25,6 +25,9 @@ type Config struct {
 	// Dependencies.
 	Log     spec.Log
 	Storage spec.Storage
+
+	// Settings.
+	InputChannel chan spec.NetworkPayload
 }
 
 // DefaultConfig provides a default configuration to create a new CLG object by
@@ -39,6 +42,9 @@ func DefaultConfig() Config {
 		// Dependencies.
 		Log:     log.NewLog(log.DefaultConfig()),
 		Storage: newStorage,
+
+		// Settings.
+		InputChannel: make(chan spec.NetworkPayload, 1000),
 	}
 
 	return newConfig
@@ -52,11 +58,17 @@ func New(config Config) (spec.CLG, error) {
 		Type:   ObjectType,
 	}
 
+	// Dependencies.
 	if newCLG.Log == nil {
 		return nil, maskAnyf(invalidConfigError, "logger must not be empty")
 	}
 	if newCLG.Storage == nil {
 		return nil, maskAnyf(invalidConfigError, "storage must not be empty")
+	}
+
+	// Settings.
+	if newCLG.InputChannel == nil {
+		return nil, maskAnyf(invalidConfigError, "input channel must not be empty")
 	}
 
 	newCLG.Log.Register(newCLG.GetType())
@@ -81,29 +93,39 @@ type clg struct {
 	Type spec.ObjectType
 }
 
-func (c *clg) Calculate(inputs []reflect.Value) ([]reflect.Value, error) {
-	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(inputs))
+func (c *clg) Calculate(payload spec.NetworkPayload) (spec.NetworkPayload, error) {
+	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(payload.Args))
 	if err != nil {
-		return nil, maskAny(err)
+		return spec.NetworkPayload{}, maskAny(err)
 	}
 
-	return outputs, nil
+	calculatedPayload := spec.NetworkPayload{
+		Args:        outputs,
+		Destination: "", // This has to be decided by Network.Forward.
+		Sources:     []spec.ObjectID{payload.Destination},
+	}
+
+	return calculatedPayload, nil
 }
 
 func (c *clg) GetName() string {
 	return "greater"
 }
 
-func (c *clg) Inputs() []reflect.Type {
+func (c *clg) GetInputChannel() chan spec.NetworkPayload {
+	return c.InputChannel
+}
+
+func (c *clg) GetInputTypes() []reflect.Type {
 	t := reflect.TypeOf(c.calculate)
 
-	var clgInputs []reflect.Type
+	var inputType []reflect.Type
 
 	for i := 0; i < t.NumIn(); i++ {
-		clgInputs = append(clgInputs, t.In(i))
+		inputType = append(inputType, t.In(i))
 	}
 
-	return clgInputs
+	return inputType
 }
 
 func (c *clg) SetLog(log spec.Log) {

--- a/clg/is-between/generated.go
+++ b/clg/is-between/generated.go
@@ -25,6 +25,9 @@ type Config struct {
 	// Dependencies.
 	Log     spec.Log
 	Storage spec.Storage
+
+	// Settings.
+	InputChannel chan spec.NetworkPayload
 }
 
 // DefaultConfig provides a default configuration to create a new CLG object by
@@ -39,6 +42,9 @@ func DefaultConfig() Config {
 		// Dependencies.
 		Log:     log.NewLog(log.DefaultConfig()),
 		Storage: newStorage,
+
+		// Settings.
+		InputChannel: make(chan spec.NetworkPayload, 1000),
 	}
 
 	return newConfig
@@ -52,11 +58,17 @@ func New(config Config) (spec.CLG, error) {
 		Type:   ObjectType,
 	}
 
+	// Dependencies.
 	if newCLG.Log == nil {
 		return nil, maskAnyf(invalidConfigError, "logger must not be empty")
 	}
 	if newCLG.Storage == nil {
 		return nil, maskAnyf(invalidConfigError, "storage must not be empty")
+	}
+
+	// Settings.
+	if newCLG.InputChannel == nil {
+		return nil, maskAnyf(invalidConfigError, "input channel must not be empty")
 	}
 
 	newCLG.Log.Register(newCLG.GetType())
@@ -81,29 +93,39 @@ type clg struct {
 	Type spec.ObjectType
 }
 
-func (c *clg) Calculate(inputs []reflect.Value) ([]reflect.Value, error) {
-	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(inputs))
+func (c *clg) Calculate(payload spec.NetworkPayload) (spec.NetworkPayload, error) {
+	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(payload.Args))
 	if err != nil {
-		return nil, maskAny(err)
+		return spec.NetworkPayload{}, maskAny(err)
 	}
 
-	return outputs, nil
+	calculatedPayload := spec.NetworkPayload{
+		Args:        outputs,
+		Destination: "", // This has to be decided by Network.Forward.
+		Sources:     []spec.ObjectID{payload.Destination},
+	}
+
+	return calculatedPayload, nil
 }
 
 func (c *clg) GetName() string {
 	return "is-between"
 }
 
-func (c *clg) Inputs() []reflect.Type {
+func (c *clg) GetInputChannel() chan spec.NetworkPayload {
+	return c.InputChannel
+}
+
+func (c *clg) GetInputTypes() []reflect.Type {
 	t := reflect.TypeOf(c.calculate)
 
-	var clgInputs []reflect.Type
+	var inputType []reflect.Type
 
 	for i := 0; i < t.NumIn(); i++ {
-		clgInputs = append(clgInputs, t.In(i))
+		inputType = append(inputType, t.In(i))
 	}
 
-	return clgInputs
+	return inputType
 }
 
 func (c *clg) SetLog(log spec.Log) {

--- a/clg/is-greater/generated.go
+++ b/clg/is-greater/generated.go
@@ -25,6 +25,9 @@ type Config struct {
 	// Dependencies.
 	Log     spec.Log
 	Storage spec.Storage
+
+	// Settings.
+	InputChannel chan spec.NetworkPayload
 }
 
 // DefaultConfig provides a default configuration to create a new CLG object by
@@ -39,6 +42,9 @@ func DefaultConfig() Config {
 		// Dependencies.
 		Log:     log.NewLog(log.DefaultConfig()),
 		Storage: newStorage,
+
+		// Settings.
+		InputChannel: make(chan spec.NetworkPayload, 1000),
 	}
 
 	return newConfig
@@ -52,11 +58,17 @@ func New(config Config) (spec.CLG, error) {
 		Type:   ObjectType,
 	}
 
+	// Dependencies.
 	if newCLG.Log == nil {
 		return nil, maskAnyf(invalidConfigError, "logger must not be empty")
 	}
 	if newCLG.Storage == nil {
 		return nil, maskAnyf(invalidConfigError, "storage must not be empty")
+	}
+
+	// Settings.
+	if newCLG.InputChannel == nil {
+		return nil, maskAnyf(invalidConfigError, "input channel must not be empty")
 	}
 
 	newCLG.Log.Register(newCLG.GetType())
@@ -81,29 +93,39 @@ type clg struct {
 	Type spec.ObjectType
 }
 
-func (c *clg) Calculate(inputs []reflect.Value) ([]reflect.Value, error) {
-	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(inputs))
+func (c *clg) Calculate(payload spec.NetworkPayload) (spec.NetworkPayload, error) {
+	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(payload.Args))
 	if err != nil {
-		return nil, maskAny(err)
+		return spec.NetworkPayload{}, maskAny(err)
 	}
 
-	return outputs, nil
+	calculatedPayload := spec.NetworkPayload{
+		Args:        outputs,
+		Destination: "", // This has to be decided by Network.Forward.
+		Sources:     []spec.ObjectID{payload.Destination},
+	}
+
+	return calculatedPayload, nil
 }
 
 func (c *clg) GetName() string {
 	return "is-greater"
 }
 
-func (c *clg) Inputs() []reflect.Type {
+func (c *clg) GetInputChannel() chan spec.NetworkPayload {
+	return c.InputChannel
+}
+
+func (c *clg) GetInputTypes() []reflect.Type {
 	t := reflect.TypeOf(c.calculate)
 
-	var clgInputs []reflect.Type
+	var inputType []reflect.Type
 
 	for i := 0; i < t.NumIn(); i++ {
-		clgInputs = append(clgInputs, t.In(i))
+		inputType = append(inputType, t.In(i))
 	}
 
-	return clgInputs
+	return inputType
 }
 
 func (c *clg) SetLog(log spec.Log) {

--- a/clg/multiply/generated.go
+++ b/clg/multiply/generated.go
@@ -25,6 +25,9 @@ type Config struct {
 	// Dependencies.
 	Log     spec.Log
 	Storage spec.Storage
+
+	// Settings.
+	InputChannel chan spec.NetworkPayload
 }
 
 // DefaultConfig provides a default configuration to create a new CLG object by
@@ -39,6 +42,9 @@ func DefaultConfig() Config {
 		// Dependencies.
 		Log:     log.NewLog(log.DefaultConfig()),
 		Storage: newStorage,
+
+		// Settings.
+		InputChannel: make(chan spec.NetworkPayload, 1000),
 	}
 
 	return newConfig
@@ -52,11 +58,17 @@ func New(config Config) (spec.CLG, error) {
 		Type:   ObjectType,
 	}
 
+	// Dependencies.
 	if newCLG.Log == nil {
 		return nil, maskAnyf(invalidConfigError, "logger must not be empty")
 	}
 	if newCLG.Storage == nil {
 		return nil, maskAnyf(invalidConfigError, "storage must not be empty")
+	}
+
+	// Settings.
+	if newCLG.InputChannel == nil {
+		return nil, maskAnyf(invalidConfigError, "input channel must not be empty")
 	}
 
 	newCLG.Log.Register(newCLG.GetType())
@@ -81,29 +93,39 @@ type clg struct {
 	Type spec.ObjectType
 }
 
-func (c *clg) Calculate(inputs []reflect.Value) ([]reflect.Value, error) {
-	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(inputs))
+func (c *clg) Calculate(payload spec.NetworkPayload) (spec.NetworkPayload, error) {
+	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(payload.Args))
 	if err != nil {
-		return nil, maskAny(err)
+		return spec.NetworkPayload{}, maskAny(err)
 	}
 
-	return outputs, nil
+	calculatedPayload := spec.NetworkPayload{
+		Args:        outputs,
+		Destination: "", // This has to be decided by Network.Forward.
+		Sources:     []spec.ObjectID{payload.Destination},
+	}
+
+	return calculatedPayload, nil
 }
 
 func (c *clg) GetName() string {
 	return "multiply"
 }
 
-func (c *clg) Inputs() []reflect.Type {
+func (c *clg) GetInputChannel() chan spec.NetworkPayload {
+	return c.InputChannel
+}
+
+func (c *clg) GetInputTypes() []reflect.Type {
 	t := reflect.TypeOf(c.calculate)
 
-	var clgInputs []reflect.Type
+	var inputType []reflect.Type
 
 	for i := 0; i < t.NumIn(); i++ {
-		clgInputs = append(clgInputs, t.In(i))
+		inputType = append(inputType, t.In(i))
 	}
 
-	return clgInputs
+	return inputType
 }
 
 func (c *clg) SetLog(log spec.Log) {

--- a/clg/output/generated.go
+++ b/clg/output/generated.go
@@ -25,6 +25,9 @@ type Config struct {
 	// Dependencies.
 	Log     spec.Log
 	Storage spec.Storage
+
+	// Settings.
+	InputChannel chan spec.NetworkPayload
 }
 
 // DefaultConfig provides a default configuration to create a new CLG object by
@@ -39,6 +42,9 @@ func DefaultConfig() Config {
 		// Dependencies.
 		Log:     log.NewLog(log.DefaultConfig()),
 		Storage: newStorage,
+
+		// Settings.
+		InputChannel: make(chan spec.NetworkPayload, 1000),
 	}
 
 	return newConfig
@@ -52,11 +58,17 @@ func New(config Config) (spec.CLG, error) {
 		Type:   ObjectType,
 	}
 
+	// Dependencies.
 	if newCLG.Log == nil {
 		return nil, maskAnyf(invalidConfigError, "logger must not be empty")
 	}
 	if newCLG.Storage == nil {
 		return nil, maskAnyf(invalidConfigError, "storage must not be empty")
+	}
+
+	// Settings.
+	if newCLG.InputChannel == nil {
+		return nil, maskAnyf(invalidConfigError, "input channel must not be empty")
 	}
 
 	newCLG.Log.Register(newCLG.GetType())
@@ -81,29 +93,39 @@ type clg struct {
 	Type spec.ObjectType
 }
 
-func (c *clg) Calculate(inputs []reflect.Value) ([]reflect.Value, error) {
-	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(inputs))
+func (c *clg) Calculate(payload spec.NetworkPayload) (spec.NetworkPayload, error) {
+	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(payload.Args))
 	if err != nil {
-		return nil, maskAny(err)
+		return spec.NetworkPayload{}, maskAny(err)
 	}
 
-	return outputs, nil
+	calculatedPayload := spec.NetworkPayload{
+		Args:        outputs,
+		Destination: "", // This has to be decided by Network.Forward.
+		Sources:     []spec.ObjectID{payload.Destination},
+	}
+
+	return calculatedPayload, nil
 }
 
 func (c *clg) GetName() string {
 	return "output"
 }
 
-func (c *clg) Inputs() []reflect.Type {
+func (c *clg) GetInputChannel() chan spec.NetworkPayload {
+	return c.InputChannel
+}
+
+func (c *clg) GetInputTypes() []reflect.Type {
 	t := reflect.TypeOf(c.calculate)
 
-	var clgInputs []reflect.Type
+	var inputType []reflect.Type
 
 	for i := 0; i < t.NumIn(); i++ {
-		clgInputs = append(clgInputs, t.In(i))
+		inputType = append(inputType, t.In(i))
 	}
 
-	return clgInputs
+	return inputType
 }
 
 func (c *clg) SetLog(log spec.Log) {

--- a/clg/subtract/generated.go
+++ b/clg/subtract/generated.go
@@ -25,6 +25,9 @@ type Config struct {
 	// Dependencies.
 	Log     spec.Log
 	Storage spec.Storage
+
+	// Settings.
+	InputChannel chan spec.NetworkPayload
 }
 
 // DefaultConfig provides a default configuration to create a new CLG object by
@@ -39,6 +42,9 @@ func DefaultConfig() Config {
 		// Dependencies.
 		Log:     log.NewLog(log.DefaultConfig()),
 		Storage: newStorage,
+
+		// Settings.
+		InputChannel: make(chan spec.NetworkPayload, 1000),
 	}
 
 	return newConfig
@@ -52,11 +58,17 @@ func New(config Config) (spec.CLG, error) {
 		Type:   ObjectType,
 	}
 
+	// Dependencies.
 	if newCLG.Log == nil {
 		return nil, maskAnyf(invalidConfigError, "logger must not be empty")
 	}
 	if newCLG.Storage == nil {
 		return nil, maskAnyf(invalidConfigError, "storage must not be empty")
+	}
+
+	// Settings.
+	if newCLG.InputChannel == nil {
+		return nil, maskAnyf(invalidConfigError, "input channel must not be empty")
 	}
 
 	newCLG.Log.Register(newCLG.GetType())
@@ -81,29 +93,39 @@ type clg struct {
 	Type spec.ObjectType
 }
 
-func (c *clg) Calculate(inputs []reflect.Value) ([]reflect.Value, error) {
-	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(inputs))
+func (c *clg) Calculate(payload spec.NetworkPayload) (spec.NetworkPayload, error) {
+	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(payload.Args))
 	if err != nil {
-		return nil, maskAny(err)
+		return spec.NetworkPayload{}, maskAny(err)
 	}
 
-	return outputs, nil
+	calculatedPayload := spec.NetworkPayload{
+		Args:        outputs,
+		Destination: "", // This has to be decided by Network.Forward.
+		Sources:     []spec.ObjectID{payload.Destination},
+	}
+
+	return calculatedPayload, nil
 }
 
 func (c *clg) GetName() string {
 	return "subtract"
 }
 
-func (c *clg) Inputs() []reflect.Type {
+func (c *clg) GetInputChannel() chan spec.NetworkPayload {
+	return c.InputChannel
+}
+
+func (c *clg) GetInputTypes() []reflect.Type {
 	t := reflect.TypeOf(c.calculate)
 
-	var clgInputs []reflect.Type
+	var inputType []reflect.Type
 
 	for i := 0; i < t.NumIn(); i++ {
-		clgInputs = append(clgInputs, t.In(i))
+		inputType = append(inputType, t.In(i))
 	}
 
-	return clgInputs
+	return inputType
 }
 
 func (c *clg) SetLog(log spec.Log) {

--- a/clg/sum/generated.go
+++ b/clg/sum/generated.go
@@ -25,6 +25,9 @@ type Config struct {
 	// Dependencies.
 	Log     spec.Log
 	Storage spec.Storage
+
+	// Settings.
+	InputChannel chan spec.NetworkPayload
 }
 
 // DefaultConfig provides a default configuration to create a new CLG object by
@@ -39,6 +42,9 @@ func DefaultConfig() Config {
 		// Dependencies.
 		Log:     log.NewLog(log.DefaultConfig()),
 		Storage: newStorage,
+
+		// Settings.
+		InputChannel: make(chan spec.NetworkPayload, 1000),
 	}
 
 	return newConfig
@@ -52,11 +58,17 @@ func New(config Config) (spec.CLG, error) {
 		Type:   ObjectType,
 	}
 
+	// Dependencies.
 	if newCLG.Log == nil {
 		return nil, maskAnyf(invalidConfigError, "logger must not be empty")
 	}
 	if newCLG.Storage == nil {
 		return nil, maskAnyf(invalidConfigError, "storage must not be empty")
+	}
+
+	// Settings.
+	if newCLG.InputChannel == nil {
+		return nil, maskAnyf(invalidConfigError, "input channel must not be empty")
 	}
 
 	newCLG.Log.Register(newCLG.GetType())
@@ -81,29 +93,39 @@ type clg struct {
 	Type spec.ObjectType
 }
 
-func (c *clg) Calculate(inputs []reflect.Value) ([]reflect.Value, error) {
-	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(inputs))
+func (c *clg) Calculate(payload spec.NetworkPayload) (spec.NetworkPayload, error) {
+	outputs, err := filterError(reflect.ValueOf(c.calculate).Call(payload.Args))
 	if err != nil {
-		return nil, maskAny(err)
+		return spec.NetworkPayload{}, maskAny(err)
 	}
 
-	return outputs, nil
+	calculatedPayload := spec.NetworkPayload{
+		Args:        outputs,
+		Destination: "", // This has to be decided by Network.Forward.
+		Sources:     []spec.ObjectID{payload.Destination},
+	}
+
+	return calculatedPayload, nil
 }
 
 func (c *clg) GetName() string {
 	return "sum"
 }
 
-func (c *clg) Inputs() []reflect.Type {
+func (c *clg) GetInputChannel() chan spec.NetworkPayload {
+	return c.InputChannel
+}
+
+func (c *clg) GetInputTypes() []reflect.Type {
 	t := reflect.TypeOf(c.calculate)
 
-	var clgInputs []reflect.Type
+	var inputType []reflect.Type
 
 	for i := 0; i < t.NumIn(); i++ {
-		clgInputs = append(clgInputs, t.In(i))
+		inputType = append(inputType, t.In(i))
 	}
 
-	return clgInputs
+	return inputType
 }
 
 func (c *clg) SetLog(log spec.Log) {

--- a/network/common.go
+++ b/network/common.go
@@ -135,7 +135,7 @@ func (n *network) permutationListToTypes(permutationList spec.PermutationList) (
 	return types, nil
 }
 
-// private
+// helper
 
 func containsNetworkPayload(list []spec.NetworkPayload, item spec.NetworkPayload) bool {
 	for _, r := range list {

--- a/network/common.go
+++ b/network/common.go
@@ -198,6 +198,7 @@ func inputRequestsToPermutationList(queue []spec.NetworkPayload, desired []refle
 // always a context. When merging the network payloads the first context of the
 // first inputs list is used to be applied to the new unified network payload.
 // All contexts of the given network payloads should be equal anyway anyway.
+//
 // TODO
 // func mergeNetworkPayloads(payloads []spec.NetworkPayload) (spec.NetworkPayload, error) {
 // 	var payload spec.NetworkPayload

--- a/spec/clg.go
+++ b/spec/clg.go
@@ -4,18 +4,31 @@ import (
 	"reflect"
 )
 
-// CLG TODO
+// CLG represents the CLGs interacting with each other within the neural
+// network. Each CLG is registered in the Network. From there impulses are
+// dispatched in a dynamic fashion until some useful calculation took place.
 type CLG interface {
-	// TODO
-	Calculate(inputs []reflect.Value) ([]reflect.Value, error)
+	// Calculate provides the CLG's actual business logic.
+	Calculate(payload NetworkPayload) (NetworkPayload, error)
 
+	// GetName returns the CLG's human readable name.
 	GetName() string
 
-	Inputs() []reflect.Type
+	// GetInputChannel returns the CLG's input channel, which acts as
+	// communication channel to reach the CLG inside of the neural network.
+	GetInputChannel() chan NetworkPayload
+
+	// GetInputTypes returns the CLG's underlying input types. These reflect the
+	// real interface hidden behind the Calculate API.
+	GetInputTypes() []reflect.Type
 
 	Object
 
+	// SetLog configures the CLG's logger. This is done for all CLGs, regardless
+	// if a CLG is making use of the logger or not.
 	SetLog(log Log)
 
+	// SetStorage configures the CLG's storage. This is done for all CLGs,
+	// regardless if a CLG is making use of the logger or not.
 	SetStorage(storage Storage)
 }

--- a/spec/network.go
+++ b/spec/network.go
@@ -25,10 +25,9 @@ type NetworkPayload struct {
 // activity calculates outputs which are streamed through the output channel
 // back to the requestor.
 type Network interface {
-	// Activate decides if the requested CLG wants to be activated. To make this
-	// decision the given input, the CLGs connections and behaviour properties
-	// may be considered.
-	Activate(clgID ObjectID, inputs []reflect.Value) (bool, error)
+	// Activate decides if the requested CLG should be activated. To make this
+	// decision the given payload is considered.
+	Activate(clgID ObjectID, payload NetworkPayload) error
 
 	// Boot initializes and starts the whole network like booting a machine. The
 	// call to Boot blocks until the network is completely initialized, so you
@@ -36,25 +35,29 @@ type Network interface {
 	Boot()
 
 	// Calculate executes the activated CLG and invokes its actual implemented
-	// behaviour. This behaviour can be anything. It is up to the CLG.
-	Calculate(clgID ObjectID, inputs []reflect.Value) ([]reflect.Value, error)
+	// behaviour. This behaviour can be anything. It is up to the CLG what it
+	// does with the provided NetworkPayload.
+	Calculate(clgID ObjectID, payload NetworkPayload) (NetworkPayload, error)
 
 	// Execute takes care about a CLG's execution. It represents basically a
 	// business logic bundle of Acivate, Calculate and Forward.
-	Execute(clgID ObjectID, payload NetworkPayload) error
+	Execute(clgID ObjectID, payload NetworkPayload) (NetworkPayload, error)
 
 	// Forward is triggered after the CLGs calculation. Here is decided what to
 	// do next. Like Activate, it is up to the CLG if it forwards signals to
 	// further CLGs. E.g. a CLG may or may not forward its calculated results to
-	// one or more CLGs. All this depends on its inputs, calculated outputs, CLG
-	// connections and behaviour properties.
-	Forward(clgID ObjectID, inputs, outputs []reflect.Value) error
+	// one or more CLGs. All this depends on the information provided by the
+	// given payload, the CLG's connections and its therefore resulting behaviour
+	// properties.
+	Forward(clgID ObjectID, payload NetworkPayload) error
 
 	// Listen makes the network listen on requests from the outside. Here each
 	// CLG input channel is managed. This models Listen as kind of cortex in
 	// which impulses are dispatched into all possible direction and finally flow
-	// back again.
-	Listen()
+	// back again. Listen only returns an error in case the initialization of all
+	// listeners failed. Errors during processing of the neural network will be
+	// logged to the provided logger.
+	Listen() error
 
 	Object
 


### PR DESCRIPTION
### abstract
This PR goes towards #172. Here we integrate the new `spec.NetworkPayload` to the `spec.Network` implementation. This interface change aims to cleanup the interface and make input/output propagation more easy and better understandable. 

See also https://github.com/xh3b4sd/clggen/pull/3.

### checklist
- [x] Make sure you read and understood the [CONTRIBUTING.md](https://github.com/xh3b4sd/anna/blob/master/.github/CONTRIBUTING.md).
- [x] Make sure you applied sufficient labels, milestone and assignee.
- [x] Make sure all TODOs are addressed.
- [x] Make sure there is sufficient documentation.
- [x] Make sure there are sufficient tests.
- [ ] Make sure all commits are squashed before merging.
- [ ] Make sure to delete the feature branch after merging.
