### PR TITLE
fixed storage tests which use random factory

### DIFF
--- a/storage/memory/storage_test.go
+++ b/storage/memory/storage_test.go
@@ -359,7 +359,7 @@ func Test_Memory_GetRandomKey(t *testing.T) {
 
 	var mutex sync.Mutex
 	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 1000; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
### abstract
The recently added storage tests use the random factory. There are tests which failed because on missing entropy. This PR fixes this. It is not nice, but should work. 

### checklist
- [x] Make sure you read and understood the [CONTRIBUTING.md](https://github.com/xh3b4sd/anna/blob/master/.github/CONTRIBUTING.md).
- [x] Make sure you applied sufficient labels, milestone and assignee.
- [x] Make sure all TODOs are addressed.
- [x] Make sure there is sufficient documentation.
- [x] Make sure there are sufficient tests.
- [x] Make sure all commits are squashed before merging.
- [x] Make sure to delete the feature branch after merging.

