### PR TITLE
removed outdated MustNewID method

### DIFF
--- a/object/context/context.go
+++ b/object/context/context.go
@@ -9,7 +9,6 @@ import (
 	netcontext "golang.org/x/net/context"
 
 	"github.com/xh3b4sd/anna/object/spec"
-	"github.com/xh3b4sd/anna/service/id"
 )
 
 // Config represents the configuration used to create a new context object.
@@ -47,7 +46,7 @@ func New(config Config) (spec.Context, error) {
 	newContext := &context{
 		Config: config,
 
-		ID: string(id.MustNewID()),
+		ID: "",
 	}
 
 	if newContext.Context == nil {

--- a/object/networkpayload/networkpayload.go
+++ b/object/networkpayload/networkpayload.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/xh3b4sd/anna/object/context"
 	"github.com/xh3b4sd/anna/object/spec"
-	"github.com/xh3b4sd/anna/service/id"
 )
 
 // Config represents the configuration used to create a new
@@ -52,7 +51,7 @@ func New(config Config) (spec.NetworkPayload, error) {
 	newObject := &networkPayload{
 		Config: config,
 
-		ID: id.MustNewID(),
+		ID: "",
 	}
 
 	return newObject, nil

--- a/service/id/service.go
+++ b/service/id/service.go
@@ -26,13 +26,6 @@ func New() spec.ID {
 	return &service{}
 }
 
-// MustNewID returns a new string of type Hex128. In case of any error
-// this method panics.
-func MustNewID() string {
-	// TODO
-	return ""
-}
-
 type service struct {
 	// Dependencies.
 


### PR DESCRIPTION
### abstract
This PR removes the outdated MustNewID method.

### checklist
- [x] Make sure you read and understood the [CONTRIBUTING.md](https://github.com/xh3b4sd/anna/blob/master/.github/CONTRIBUTING.md).
- [x] Make sure you applied sufficient labels, milestone and assignee.
- [x] Make sure all TODOs are addressed.
- [x] Make sure there is sufficient documentation.
- [x] Make sure there are sufficient tests.
- [x] Make sure all commits are squashed before merging.
- [ ] Make sure to delete the feature branch after merging.

